### PR TITLE
Bugfix: Correctly build changes when using rollup watch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,9 +74,7 @@ module.exports = function sass (options = {}) {
         return Promise.resolve({ id, code, map })
           .then(options.postProcess)
           .then(style => {
-            if (!styleMaps[id]) {
-              styles.push(styleMaps[id] = style)
-            }
+            styleMaps[id] = style
             if (options.insert === true) {
               return {
                 id: id,
@@ -97,9 +95,11 @@ module.exports = function sass (options = {}) {
       }
     },
     async generateBundle (generateOptions) {
-      if (!styles.length || options.output === false) {
+      if (!Object.keys(styleMaps).length || options.output === false) {
         return
       }
+      
+      const styles = Object.keys(styleMaps).map((id) => styleMaps[id]);
 
       if (typeof options.output === 'function') {
         return options.output(styles)


### PR DESCRIPTION
Hi,

we switched from inlining the css code to an external bundle and realized that changes are not in the output file when using a bundle.
This is because the styleMap is not reset between runs which is why we always need to update it.